### PR TITLE
Fix how to make selfLink

### DIFF
--- a/server/plugin.go
+++ b/server/plugin.go
@@ -35,7 +35,7 @@ func (p *Plugin) MessageWillBePosted(c *plugin.Context, post *model.Post) (*mode
 		return post, err.Message
 	}
 
-	selfLink := fmt.Sprintf("https://%s/%s", *siteURL, team.Name)
+	selfLink := fmt.Sprintf("%s/%s", *siteURL, team.Name)
 	selfLinkPattern, er := regexp.Compile(fmt.Sprintf("%s%s", selfLink, `/[\w/]+`))
 	if er != nil {
 		return post, er.Error()


### PR DESCRIPTION
Since `SiteURL` should have the protocol, no need to include `https://`.
https://docs.mattermost.com/administration/config-settings.html#site-url